### PR TITLE
Change password to in-line code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ My malware repository isn't excellent, however, I am trying my best to convince 
 ![About](https://malwat.ch/images/assets/malwareCollection.png)
 
 ### Password
-The password for all archives is **mysubsarethebest**!
+The password for all archives is `mysubsarethebest`!
 
 ### Percentage
 Here is a table of approximate percentage ratio of malware in my repository.
@@ -47,7 +47,7 @@ Self-made / Viewer-made | 5%
 # FAQ
 ### Here you can find answers to frequently asked questions. This may be helpful!
 **Q:** What is the password for the archive I've downloaded?  
-**A:** It is **mysubsarethebest**... Read the description carefully!
+**A:** It is `mysubsarethebest`... Read the description carefully!
 
 **Q:** I know I didn't misspell the password for the archive, however it STILL won't unlock. What do I do?  
 **A:** Check for the mistakes again, if it doesn't help then create an issue, I will reupload the one you're struggling with. Mistakes can happen!


### PR DESCRIPTION
This PR aims to enhance the README file.

The current password can be ambiguous to readers due to punctuation marks which can be interpreted as part of the password. By changing the formatting to in-line code, the password will be appear more clearly without much effects on the general tone.